### PR TITLE
Replace jersey SVG with three.js rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "lucide-react": "^0.475.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
+                "three": "^0.171.0",
                 "tailwind-merge": "^3.0.1",
                 "tailwindcss": "^4.0.0",
                 "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "lucide-react": "^0.475.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "three": "^0.171.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",
         "tailwindcss-animate": "^1.0.7",

--- a/resources/js/components/PlayerJersey.tsx
+++ b/resources/js/components/PlayerJersey.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
 
 interface PlayerJerseyProps {
     teamName?: string;
@@ -11,6 +12,341 @@ interface PlayerJerseyProps {
     className?: string;
 }
 
+interface JerseyCanvasProps {
+    width: number;
+    height: number;
+    primary: string;
+    secondary: string;
+    view: 'front' | 'back';
+    className?: string;
+    tilt?: number;
+    children?: React.ReactNode;
+}
+
+interface JerseySceneOptions {
+    width: number;
+    height: number;
+    primary: string;
+    secondary: string;
+    view: 'front' | 'back';
+    tilt: number;
+}
+
+const SIZE_CONFIG = {
+    sm: { width: 120, height: 150 },
+    md: { width: 180, height: 220 },
+    lg: { width: 240, height: 290 },
+} as const;
+
+function sanitizeColor(color: string | undefined, fallback: string): string {
+    if (!color) {
+        return fallback;
+    }
+
+    try {
+        const parsed = new THREE.Color(color);
+        return `#${parsed.getHexString()}`;
+    } catch {
+        try {
+            const parsedFallback = new THREE.Color(fallback);
+            return `#${parsedFallback.getHexString()}`;
+        } catch {
+            return '#000000';
+        }
+    }
+}
+
+function splitNameIntoLines(name: string | undefined, maxPerLine: number): string[] {
+    const safe = (name ?? '').trim();
+    if (!safe) {
+        return ['TEAM'];
+    }
+
+    const words = safe.split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+        return ['TEAM'];
+    }
+
+    if (words.length === 1) {
+        return [words[0].slice(0, maxPerLine).toUpperCase()];
+    }
+
+    const lines: string[] = [];
+    let current = '';
+
+    words.forEach((word) => {
+        const candidate = current ? `${current} ${word}` : word;
+        if (candidate.length > maxPerLine && current) {
+            lines.push(current.toUpperCase());
+            current = word;
+        } else {
+            current = candidate;
+        }
+    });
+
+    if (current) {
+        lines.push(current.toUpperCase());
+    }
+
+    return lines.slice(0, 3).map((line) => line.slice(0, maxPerLine).toUpperCase());
+}
+
+function extractLastName(name: string | undefined, maxLength: number): string {
+    const safe = (name ?? '').trim();
+    if (!safe) {
+        return 'PLAYER';
+    }
+
+    const parts = safe.split(/\s+/).filter(Boolean);
+    const value = parts.length > 0 ? parts[parts.length - 1] : safe;
+    return value.slice(0, maxLength).toUpperCase();
+}
+
+function useThreeJersey(canvasRef: React.RefObject<HTMLCanvasElement | null>, options: JerseySceneOptions) {
+    const { width, height, primary, secondary, view, tilt } = options;
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return;
+        }
+
+        const dispose = initializeThreeJersey(canvas, { width, height, primary, secondary, view, tilt });
+        return () => {
+            dispose();
+        };
+    }, [canvasRef, width, height, primary, secondary, view, tilt]);
+}
+
+function initializeThreeJersey(canvas: HTMLCanvasElement, options: JerseySceneOptions) {
+    const { width, height, primary, secondary, view, tilt } = options;
+
+    canvas.width = width;
+    canvas.height = height;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    const pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio, 2) : 1;
+    renderer.setPixelRatio(pixelRatio);
+    renderer.setSize(width, height, false);
+    renderer.shadowMap.enabled = true;
+
+    const scene = new THREE.Scene();
+
+    const camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100);
+    camera.position.set(0, 1.5, 8);
+    camera.lookAt(0, 0.4, 0);
+    scene.add(camera);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.9);
+    const keyLight = new THREE.DirectionalLight(0xffffff, 1.05);
+    keyLight.position.set(6, 8, 6);
+    keyLight.castShadow = true;
+    keyLight.shadow.bias = -0.0002;
+    keyLight.shadow.mapSize.set(1024, 1024);
+
+    const rimLight = new THREE.DirectionalLight(0xffffff, 0.35);
+    rimLight.position.set(-6, 4, -4);
+
+    const fillLight = new THREE.PointLight(0xffffff, 0.25, 20, 2);
+    fillLight.position.set(0, 2, -4);
+
+    scene.add(ambient);
+    scene.add(keyLight);
+    scene.add(rimLight);
+    scene.add(fillLight);
+
+    const jerseyGroup = new THREE.Group();
+    jerseyGroup.rotation.x = tilt;
+    jerseyGroup.position.y = -0.3;
+    scene.add(jerseyGroup);
+
+    const geometries: THREE.BufferGeometry[] = [];
+    const materials: THREE.Material[] = [];
+
+    const primaryColor = new THREE.Color(primary);
+    const secondaryColor = new THREE.Color(secondary);
+
+    const bodyGeometry = new THREE.BoxGeometry(3.3, 4.3, 1.25, 16, 16, 8);
+    const bodyPositions = bodyGeometry.attributes.position;
+    const vertex = new THREE.Vector3();
+
+    for (let index = 0; index < bodyPositions.count; index += 1) {
+        vertex.fromBufferAttribute(bodyPositions, index);
+        const taper = vertex.y > 1.4 ? 1.08 : vertex.y < -1.6 ? 0.78 : 1;
+        vertex.x *= taper;
+        vertex.z *= taper * 0.95;
+        bodyPositions.setXYZ(index, vertex.x, vertex.y, vertex.z);
+    }
+
+    bodyGeometry.computeVertexNormals();
+    geometries.push(bodyGeometry);
+
+    const bodyMaterial = new THREE.MeshStandardMaterial({
+        color: primaryColor,
+        roughness: 0.45,
+        metalness: 0.15,
+    });
+    materials.push(bodyMaterial);
+
+    const bodyMesh = new THREE.Mesh(bodyGeometry, bodyMaterial);
+    bodyMesh.castShadow = true;
+    bodyMesh.receiveShadow = true;
+    jerseyGroup.add(bodyMesh);
+
+    const sleeveColor = primaryColor.clone();
+    sleeveColor.offsetHSL(0, 0, 0.08);
+
+    const sleeveMaterial = new THREE.MeshStandardMaterial({
+        color: sleeveColor,
+        roughness: 0.5,
+        metalness: 0.12,
+    });
+    materials.push(sleeveMaterial);
+
+    const sleeveGeometry = new THREE.BoxGeometry(1.45, 1.3, 1.3, 8, 8, 6);
+    geometries.push(sleeveGeometry);
+
+    const leftSleeve = new THREE.Mesh(sleeveGeometry, sleeveMaterial);
+    leftSleeve.position.set(-2.25, 0.8, 0);
+    leftSleeve.rotation.z = 0.35;
+    leftSleeve.castShadow = true;
+    jerseyGroup.add(leftSleeve);
+
+    const rightSleeve = leftSleeve.clone();
+    rightSleeve.position.x = 2.25;
+    rightSleeve.rotation.z = -0.35;
+    jerseyGroup.add(rightSleeve);
+
+    const cuffMaterial = new THREE.MeshStandardMaterial({
+        color: secondaryColor,
+        roughness: 0.38,
+        metalness: 0.22,
+    });
+    materials.push(cuffMaterial);
+
+    const cuffGeometry = new THREE.BoxGeometry(1.48, 0.34, 1.32, 4, 4, 4);
+    geometries.push(cuffGeometry);
+
+    const leftCuff = new THREE.Mesh(cuffGeometry, cuffMaterial);
+    leftCuff.position.set(-2.33, 0.1, 0.02);
+    leftCuff.rotation.z = 0.35;
+    jerseyGroup.add(leftCuff);
+
+    const rightCuff = leftCuff.clone();
+    rightCuff.position.x = 2.33;
+    rightCuff.rotation.z = -0.35;
+    jerseyGroup.add(rightCuff);
+
+    const stripeMaterial = new THREE.MeshStandardMaterial({
+        color: secondaryColor,
+        roughness: 0.3,
+        metalness: 0.28,
+        transparent: true,
+        opacity: 0.95,
+    });
+    materials.push(stripeMaterial);
+
+    const chestStripeGeometry = new THREE.BoxGeometry(3.3, 0.45, 1.32, 8, 2, 6);
+    geometries.push(chestStripeGeometry);
+
+    const frontStripe = new THREE.Mesh(chestStripeGeometry, stripeMaterial);
+    frontStripe.position.set(0, 1.05, 0.62);
+    jerseyGroup.add(frontStripe);
+
+    const backStripe = frontStripe.clone();
+    backStripe.position.z = -0.62;
+    backStripe.rotation.y = Math.PI;
+    jerseyGroup.add(backStripe);
+
+    const sideStripeGeometry = new THREE.BoxGeometry(0.22, 3.8, 1.28, 4, 12, 6);
+    geometries.push(sideStripeGeometry);
+
+    const leftSideStripe = new THREE.Mesh(sideStripeGeometry, stripeMaterial);
+    leftSideStripe.position.set(-1.68, -0.2, 0);
+    jerseyGroup.add(leftSideStripe);
+
+    const rightSideStripe = leftSideStripe.clone();
+    rightSideStripe.position.x = 1.68;
+    jerseyGroup.add(rightSideStripe);
+
+    const collarMaterial = new THREE.MeshStandardMaterial({
+        color: secondaryColor,
+        roughness: 0.25,
+        metalness: 0.3,
+    });
+    materials.push(collarMaterial);
+
+    const collarGeometry = new THREE.TorusGeometry(0.78, 0.12, 22, 64, Math.PI * 1.6);
+    geometries.push(collarGeometry);
+    const collarMesh = new THREE.Mesh(collarGeometry, collarMaterial);
+    collarMesh.rotation.x = Math.PI / 2;
+    collarMesh.rotation.z = Math.PI / 2;
+    collarMesh.position.set(0, 2.25, 0.05);
+    jerseyGroup.add(collarMesh);
+
+    const collarBack = collarMesh.clone();
+    collarBack.position.z = -0.05;
+    jerseyGroup.add(collarBack);
+
+    const floorGeometry = new THREE.CircleGeometry(3.3, 32);
+    geometries.push(floorGeometry);
+    const floorMaterial = new THREE.MeshStandardMaterial({
+        color: new THREE.Color('#000000'),
+        transparent: true,
+        opacity: 0.18,
+        roughness: 1,
+        metalness: 0,
+    });
+    materials.push(floorMaterial);
+
+    const floorMesh = new THREE.Mesh(floorGeometry, floorMaterial);
+    floorMesh.rotation.x = -Math.PI / 2;
+    floorMesh.position.y = -2.55;
+    floorMesh.receiveShadow = true;
+    scene.add(floorMesh);
+
+    const baseRotation = view === 'front' ? 0 : Math.PI;
+
+    let frameId = 0;
+    const start = typeof performance !== 'undefined' ? performance.now() : 0;
+
+    const animate = (now: number) => {
+        const elapsed = (now - start) / 1000;
+        const wobble = Math.sin(elapsed * 1.2) * 0.18;
+        const float = Math.sin(elapsed * 1.5) * 0.08;
+
+        jerseyGroup.rotation.y = baseRotation + wobble;
+        jerseyGroup.position.y = -0.3 + float;
+
+        keyLight.position.x = 6 * Math.cos(elapsed * 0.6);
+        keyLight.position.z = 6 * Math.sin(elapsed * 0.6);
+
+        renderer.render(scene, camera);
+        frameId = requestAnimationFrame(animate);
+    };
+
+    frameId = requestAnimationFrame(animate);
+
+    return () => {
+        cancelAnimationFrame(frameId);
+        renderer.dispose();
+
+        geometries.forEach((geometry) => {
+            geometry.dispose();
+        });
+
+        materials.forEach((material) => {
+            material.dispose();
+        });
+
+        scene.clear();
+    };
+}
+
 export function PlayerJersey({
     teamName = 'TEAM',
     playerName = 'PLAYER',
@@ -21,212 +357,122 @@ export function PlayerJersey({
     size = 'md',
     className = '',
 }: PlayerJerseyProps) {
-    // Size configurations
-    const sizes = {
-        sm: { width: 100, height: 100, fontSize: 7, numberSize: 14, scale: 0.01 },
-        md: { width: 150, height: 150, fontSize: 11, numberSize: 22, scale: 0.015 },
-        lg: { width: 200, height: 200, fontSize: 14, numberSize: 28, scale: 0.02 },
-    };
+    const config = SIZE_CONFIG[size];
+    const primary = useMemo(() => sanitizeColor(primaryColor, '#000000'), [primaryColor]);
+    const secondary = useMemo(() => sanitizeColor(secondaryColor, '#FFFFFF'), [secondaryColor]);
+    const jerseyLabel = useMemo(() => `${jerseyNumber ?? '00'}`, [jerseyNumber]);
+    const teamLines = useMemo(() => splitNameIntoLines(teamName, 12), [teamName]);
+    const lastName = useMemo(() => extractLastName(playerName, 12), [playerName]);
 
-    const config = sizes[size];
-
-    // Use defaults if colors are not provided
-    const primary = primaryColor || '#000000';
-    const secondary = secondaryColor || '#FFFFFF';
+    const frontNameFont = config.width * 0.16;
+    const frontNumberFont = config.width * 0.36;
+    const backNumberFont = config.width * 0.58;
+    const backNameFont = config.width * 0.2;
 
     return (
-        <svg
+        <JerseyCanvas
             width={config.width}
             height={config.height}
-            viewBox="0 0 1000 1000"
+            primary={primary}
+            secondary={secondary}
+            view={view}
             className={className}
-            xmlns="http://www.w3.org/2000/svg"
+            tilt={-0.18}
         >
-            <defs>
-                <linearGradient id={`jersey-gradient-${view}-${size}`} x1="0%" y1="0%" x2="0%" y2="100%">
-                    <stop offset="0%" style={{ stopColor: primary, stopOpacity: 1 }} />
-                    <stop offset="50%" style={{ stopColor: primary, stopOpacity: 0.95 }} />
-                    <stop offset="100%" style={{ stopColor: primary, stopOpacity: 0.9 }} />
-                </linearGradient>
-                <filter id={`shadow-${view}-${size}`}>
-                    <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
-                    <feOffset dx="0" dy="2" result="offsetblur"/>
-                    <feComponentTransfer>
-                        <feFuncA type="linear" slope="0.3"/>
-                    </feComponentTransfer>
-                    <feMerge>
-                        <feMergeNode/>
-                        <feMergeNode in="SourceGraphic"/>
-                    </feMerge>
-                </filter>
-            </defs>
-
-            {view === 'front' ? (
-                <g transform="translate(0, -110)">
-                    {/* T-Shirt Body - Using the provided SVG path */}
-                    <g transform="scale(1.0, 1.0)">
-                        <path
-                            d="M2886.3,4377.7c-136.3-80.7-420.5-247.7-629.8-366.8c-796.9-462.8-1242.4-877.5-1728.2-1609.1c-170.9-261.1-376.4-622.2-416.7-737.4c-32.6-97.9,3.8-180.5,109.5-245.8c44.2-26.9,497.3-261.2,1008.1-518.5c781.5-395.6,937.1-468.5,983.1-457c34.6,9.6,74.9,49.9,122.9,119.1c38.4,59.5,71,103.7,74.9,101.8c23-25-190.1-2302.4-387.9-4145.8c-38.4-364.8-65.3-685.5-57.6-714.3c28.8-115.2-151.7-109.5,3043.6-109.5h2918.8l53.8,46.1l51.9,46.1l-51.9,697c-138.3,1826.1-282.3,3898-282.3,4067v78.7l92.2-96c53.8-55.7,109.5-96,132.5-96c38.4,0,445.5,217,1470.9,785.4c387.9,217,495.4,284.2,505,320.7c13.4,53.8-101.8,278.4-330.3,645.2c-364.8,585.7-637.5,939-927.5,1205.9c-291.9,270.8-445.5,370.6-942.8,624.1c-259.2,130.6-547.3,282.3-641.4,336c-261.1,151.7-232.3,149.8-478.1,28.8c-251.6-121-591.4-238.1-877.5-301.5c-176.7-38.4-255.4-44.2-643.3-44.2c-386,0-468.5,5.8-658.6,44.2c-366.8,73-781.5,224.7-1044.6,380.2c-63.4,36.5-136.3,65.3-165.1,63.4C3160.9,4525.5,3024.5,4458.3,2886.3,4377.7z"
-                            fill={`url(#jersey-gradient-${view}-${size})`}
-                            stroke={secondary}
-                            strokeWidth="20"
-                            transform="translate(0, 511) scale(0.1, -0.1)"
-                            filter={`url(#shadow-${view}-${size})`}
-                        />
-                    </g>
-                    
-                    {/* Collar Overlay */}
-                    <ellipse
-                        cx="500"
-                        cy="180"
-                        rx="80"
-                        ry="40"
-                        fill={secondary}
-                        stroke={secondary}
-                        strokeWidth="2"
-                    />
-
-                    {/* Team Name on Front - Split into multiple lines if spaces exist */}
-                    {(() => {
-                        const words = teamName.trim().split(' ').filter(w => w.length > 0);
-                        const lineHeight = 90;
-                        const startY = 380;
-                        
-                        if (words.length === 1) {
-                            // Single word - show as is
-                            return (
-                                <text
-                                    x="500"
-                                    y="450"
-                                    textAnchor="middle"
-                                    fill={secondary}
-                                    fontSize="80"
-                                    fontWeight="bold"
-                                    fontFamily="Arial, sans-serif"
-                                    style={{ textTransform: 'uppercase', letterSpacing: '2px' }}
+            <div className="pointer-events-none absolute inset-0">
+                {view === 'front' ? (
+                    <>
+                        <div className="absolute left-0 right-0 flex flex-col items-center gap-1" style={{ top: '30%' }}>
+                            {teamLines.map((line, index) => (
+                                <span
+                                    key={index}
+                                    className="uppercase font-extrabold tracking-[0.25em]"
+                                    style={{
+                                        color: secondary,
+                                        fontSize: `${frontNameFont}px`,
+                                        lineHeight: 1.05,
+                                        textShadow: '0 3px 8px rgba(0,0,0,0.45)',
+                                    }}
                                 >
-                                    {words[0].substring(0, 12)}
-                                </text>
-                            );
-                        } else {
-                            // Multiple words - split into lines
-                            return (
-                                <g>
-                                    {words.map((word, index) => (
-                                        <text
-                                            key={index}
-                                            x="500"
-                                            y={startY + (index * lineHeight)}
-                                            textAnchor="middle"
-                                            fill={secondary}
-                                            fontSize="80"
-                                            fontWeight="bold"
-                                            fontFamily="Arial, sans-serif"
-                                            style={{ textTransform: 'uppercase', letterSpacing: '2px' }}
-                                        >
-                                            {word.substring(0, 10)}
-                                        </text>
-                                    ))}
-                                </g>
-                            );
-                        }
-                    })()}
-
-                    {/* Small number on front chest */}
-                    <text
-                        x="500"
-                        y="650"
-                        textAnchor="middle"
-                        fill={secondary}
-                        fontSize="120"
-                        fontWeight="bold"
-                        fontFamily="Arial, sans-serif"
-                    >
-                        {jerseyNumber}
-                    </text>
-                </g>
-            ) : (
-                <g transform="translate(0, -110)">
-                    {/* T-Shirt Body - Back View */}
-                    <g transform="scale(1.0, 1.0)">
-                        <path
-                            d="M2886.3,4377.7c-136.3-80.7-420.5-247.7-629.8-366.8c-796.9-462.8-1242.4-877.5-1728.2-1609.1c-170.9-261.1-376.4-622.2-416.7-737.4c-32.6-97.9,3.8-180.5,109.5-245.8c44.2-26.9,497.3-261.2,1008.1-518.5c781.5-395.6,937.1-468.5,983.1-457c34.6,9.6,74.9,49.9,122.9,119.1c38.4,59.5,71,103.7,74.9,101.8c23-25-190.1-2302.4-387.9-4145.8c-38.4-364.8-65.3-685.5-57.6-714.3c28.8-115.2-151.7-109.5,3043.6-109.5h2918.8l53.8,46.1l51.9,46.1l-51.9,697c-138.3,1826.1-282.3,3898-282.3,4067v78.7l92.2-96c53.8-55.7,109.5-96,132.5-96c38.4,0,445.5,217,1470.9,785.4c387.9,217,495.4,284.2,505,320.7c13.4,53.8-101.8,278.4-330.3,645.2c-364.8,585.7-637.5,939-927.5,1205.9c-291.9,270.8-445.5,370.6-942.8,624.1c-259.2,130.6-547.3,282.3-641.4,336c-261.1,151.7-232.3,149.8-478.1,28.8c-251.6-121-591.4-238.1-877.5-301.5c-176.7-38.4-255.4-44.2-643.3-44.2c-386,0-468.5,5.8-658.6,44.2c-366.8,73-781.5,224.7-1044.6,380.2c-63.4,36.5-136.3,65.3-165.1,63.4C3160.9,4525.5,3024.5,4458.3,2886.3,4377.7z"
-                            fill={`url(#jersey-gradient-${view}-${size})`}
-                            stroke={secondary}
-                            strokeWidth="20"
-                            transform="translate(0, 511) scale(0.1, -0.1)"
-                            filter={`url(#shadow-${view}-${size})`}
-                        />
-                    </g>
-                    
-                    {/* Back Collar */}
-                    <rect
-                        x="420"
-                        y="150"
-                        width="160"
-                        height="50"
-                        fill={secondary}
-                        stroke={secondary}
-                        strokeWidth="2"
-                        rx="5"
-                    />
-
-                    {/* Large Number on Back */}
-                    <text
-                        x="500"
-                        y="500"
-                        textAnchor="middle"
-                        fill={secondary}
-                        fontSize="250"
-                        fontWeight="bold"
-                        fontFamily="Arial, sans-serif"
-                        stroke={secondary}
-                        strokeWidth="2"
-                    >
-                        {jerseyNumber}
-                    </text>
-
-                    {/* Player Name on Back */}
-                    {(() => {
-                        // Get last name (or full name if single word)
-                        const nameParts = playerName.split(' ').filter(w => w.length > 0);
-                        const lastName = nameParts.length > 0 ? nameParts[nameParts.length - 1] : playerName;
-                        
-                        return (
-                            <text
-                                x="500"
-                                y="750"
-                                textAnchor="middle"
-                                fill={secondary}
-                                fontSize="70"
-                                fontWeight="bold"
-                                fontFamily="Arial, sans-serif"
-                                style={{ textTransform: 'uppercase', letterSpacing: '3px' }}
+                                    {line}
+                                </span>
+                            ))}
+                        </div>
+                        <div className="absolute left-0 right-0 text-center font-black" style={{ top: '58%' }}>
+                            <span
+                                style={{
+                                    color: secondary,
+                                    fontSize: `${frontNumberFont}px`,
+                                    letterSpacing: '0.08em',
+                                    textShadow: '0 4px 12px rgba(0,0,0,0.55)',
+                                }}
                             >
-                                {lastName.substring(0, 10)}
-                            </text>
-                        );
-                    })()}
-                </g>
-            )}
-
-            {/* Shadow/3D effect */}
-            <ellipse
-                cx={config.width * 0.5}
-                cy={config.height * 0.92}
-                rx={config.width * 0.35}
-                ry={config.height * 0.05}
-                fill="rgba(0,0,0,0.2)"
-            />
-        </svg>
+                                {jerseyLabel}
+                            </span>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <div className="absolute left-0 right-0 text-center font-black" style={{ top: '44%' }}>
+                            <span
+                                style={{
+                                    color: secondary,
+                                    fontSize: `${backNumberFont}px`,
+                                    letterSpacing: '0.05em',
+                                    textShadow: '0 4px 14px rgba(0,0,0,0.6)',
+                                }}
+                            >
+                                {jerseyLabel}
+                            </span>
+                        </div>
+                        <div className="absolute left-0 right-0 text-center uppercase font-extrabold" style={{ top: '74%' }}>
+                            <span
+                                className="tracking-[0.32em]"
+                                style={{
+                                    color: secondary,
+                                    fontSize: `${backNameFont}px`,
+                                    textShadow: '0 3px 8px rgba(0,0,0,0.45)',
+                                }}
+                            >
+                                {lastName}
+                            </span>
+                        </div>
+                    </>
+                )}
+            </div>
+        </JerseyCanvas>
     );
 }
 
-// Smaller bust version for dashboard
+function JerseyCanvas({
+    width,
+    height,
+    primary,
+    secondary,
+    view,
+    className = '',
+    tilt = -0.18,
+    children,
+}: JerseyCanvasProps) {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    useThreeJersey(canvasRef, { width, height, primary, secondary, view, tilt });
+
+    return (
+        <div
+            className={`relative inline-flex items-center justify-center ${className}`}
+            style={{ width, height }}
+        >
+            <canvas ref={canvasRef} width={width} height={height} className="h-full w-full" />
+            {children}
+        </div>
+    );
+}
+
 export function PlayerBust({
-    teamName,
-    primaryColor,
-    secondaryColor,
+    teamName = 'TEAM',
+    primaryColor = '#000000',
+    secondaryColor = '#FFFFFF',
     className = '',
 }: {
     teamName?: string;
@@ -234,96 +480,43 @@ export function PlayerBust({
     secondaryColor?: string;
     className?: string;
 }) {
-    const primary = primaryColor || '#000000';
-    const secondary = secondaryColor || '#FFFFFF';
+    const width = 120;
+    const height = 150;
+
+    const primary = useMemo(() => sanitizeColor(primaryColor, '#000000'), [primaryColor]);
+    const secondary = useMemo(() => sanitizeColor(secondaryColor, '#FFFFFF'), [secondaryColor]);
+    const teamLines = useMemo(() => splitNameIntoLines(teamName, 10), [teamName]);
+
+    const fontSize = width * 0.18;
 
     return (
-        <svg
-            width="60"
-            height="70"
-            viewBox="0 0 1000 1000"
+        <JerseyCanvas
+            width={width}
+            height={height}
+            primary={primary}
+            secondary={secondary}
+            view="front"
             className={className}
-            xmlns="http://www.w3.org/2000/svg"
+            tilt={-0.12}
         >
-            <defs>
-                <linearGradient id="bust-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                    <stop offset="0%" style={{ stopColor: primary, stopOpacity: 1 }} />
-                    <stop offset="100%" style={{ stopColor: primary, stopOpacity: 0.85 }} />
-                </linearGradient>
-                <filter id="bust-shadow" x="-50%" y="-50%" width="200%" height="200%">
-                    <feDropShadow dx="0" dy="4" stdDeviation="3" floodOpacity="0.15" />
-                </filter>
-            </defs>
-
-            <g transform="translate(0, -110)">
-                {/* T-Shirt Body - Bust View */}
-                <g transform="scale(1.0, 1.0)">
-                    <path
-                        d="M2886.3,4377.7c-136.3-80.7-420.5-247.7-629.8-366.8c-796.9-462.8-1242.4-877.5-1728.2-1609.1c-170.9-261.1-376.4-622.2-416.7-737.4c-32.6-97.9,3.8-180.5,109.5-245.8c44.2-26.9,497.3-261.2,1008.1-518.5c781.5-395.6,937.1-468.5,983.1-457c34.6,9.6,74.9,49.9,122.9,119.1c38.4,59.5,71,103.7,74.9,101.8c23-25-190.1-2302.4-387.9-4145.8c-38.4-364.8-65.3-685.5-57.6-714.3c28.8-115.2-151.7-109.5,3043.6-109.5h2918.8l53.8,46.1l51.9,46.1l-51.9,697c-138.3,1826.1-282.3,3898-282.3,4067v78.7l92.2-96c53.8-55.7,109.5-96,132.5-96c38.4,0,445.5,217,1470.9,785.4c387.9,217,495.4,284.2,505,320.7c13.4,53.8-101.8,278.4-330.3,645.2c-364.8,585.7-637.5,939-927.5,1205.9c-291.9,270.8-445.5,370.6-942.8,624.1c-259.2,130.6-547.3,282.3-641.4,336c-261.1,151.7-232.3,149.8-478.1,28.8c-251.6-121-591.4-238.1-877.5-301.5c-176.7-38.4-255.4-44.2-643.3-44.2c-386,0-468.5,5.8-658.6,44.2c-366.8,73-781.5,224.7-1044.6,380.2c-63.4,36.5-136.3,65.3-165.1,63.4C3160.9,4525.5,3024.5,4458.3,2886.3,4377.7z"
-                        fill="url(#bust-gradient)"
-                        stroke={secondary}
-                        strokeWidth="20"
-                        transform="translate(0, 511) scale(0.1, -0.1)"
-                        filter="url(#bust-shadow)"
-                    />
-                </g>
-                
-                {/* Collar */}
-                <ellipse
-                    cx="500"
-                    cy="180"
-                    rx="80"
-                    ry="40"
-                    fill={secondary}
-                    stroke={secondary}
-                    strokeWidth="2"
-                />
-
-                {/* Team Name - Split into multiple lines if spaces exist */}
-                {(() => {
-                    const name = teamName || 'TEAM';
-                    const words = name.trim().split(' ').filter(w => w.length > 0);
-                    const lineHeight = 90;
-                    const startY = 380;
-                    
-                    if (words.length === 1) {
-                        return (
-                            <text
-                                x="500"
-                                y="450"
-                                textAnchor="middle"
-                                fill={secondary}
-                                fontSize="80"
-                                fontWeight="bold"
-                                fontFamily="Arial, sans-serif"
-                                style={{ textTransform: 'uppercase', letterSpacing: '2px' }}
-                            >
-                                {words[0].substring(0, 8)}
-                            </text>
-                        );
-                    } else {
-                        return (
-                            <g>
-                                {words.map((word, index) => (
-                                    <text
-                                        key={index}
-                                        x="500"
-                                        y={startY + (index * lineHeight)}
-                                        textAnchor="middle"
-                                        fill={secondary}
-                                        fontSize="70"
-                                        fontWeight="bold"
-                                        fontFamily="Arial, sans-serif"
-                                        style={{ textTransform: 'uppercase', letterSpacing: '2px' }}
-                                    >
-                                        {word.substring(0, 8)}
-                                    </text>
-                                ))}
-                            </g>
-                        );
-                    }
-                })()}
-            </g>
-        </svg>
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute left-0 right-0 flex flex-col items-center gap-[2px]" style={{ top: '63%' }}>
+                    {teamLines.map((line, index) => (
+                        <span
+                            key={index}
+                            className="uppercase font-semibold tracking-[0.2em]"
+                            style={{
+                                color: secondary,
+                                fontSize: `${fontSize}px`,
+                                lineHeight: 1.05,
+                                textShadow: '0 2px 6px rgba(0,0,0,0.4)',
+                            }}
+                        >
+                            {line}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        </JerseyCanvas>
     );
 }


### PR DESCRIPTION
## Summary
- replace the old SVG-based jersey drawing with a reusable three.js renderer that builds and animates a 3D kit
- overlay jersey name, number, and player name so the new canvas mirrors the previous front/back layouts
- update the smaller PlayerBust view and add the three.js dependency to package metadata

## Testing
- npm run types *(fails: repository lacks generated route typings and the environment cannot download three.js, so TypeScript cannot resolve those modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ee7e18dcec8323a2ce5e0de5ca82ba